### PR TITLE
Valid C#/java literals

### DIFF
--- a/src/common/generator.js
+++ b/src/common/generator.js
@@ -533,7 +533,7 @@ window.POG=(function() {
         removeNodes(hiddens);
         // ng:view template doesn't have height,
         // hence it will considered as hidden
-        if (clonedNode.textContent.trim() === '') {
+        if (typeof clonedNode.textContent === 'string' && clonedNode.textContent.trim() === '') {
             clonedNode = excludedNode;
         }
         return clonedNode;

--- a/src/common/generator.js
+++ b/src/common/generator.js
@@ -16,7 +16,7 @@ window.POG=(function() {
         if (value) {
             var selector = node.nodeName.toLowerCase();
             if (name === 'class') {
-                selector += '.' + value.split(/\s+/g).join('.');
+                selector += '.' + value.trim().split(/\s+/g).join('.');
             }
             else {
                 selector += '[' + name + '=\'' + value + '\']';

--- a/src/common/generator.js
+++ b/src/common/generator.js
@@ -533,7 +533,7 @@ window.POG=(function() {
         removeNodes(hiddens);
         // ng:view template doesn't have height,
         // hence it will considered as hidden
-        if (typeof clonedNode.textContent === 'string' && clonedNode.textContent.trim() === '') {
+        if ((clonedNode.textContent || '').trim() === '') {
             clonedNode = excludedNode;
         }
         return clonedNode;

--- a/src/common/generator.js
+++ b/src/common/generator.js
@@ -108,6 +108,13 @@ window.POG=(function() {
         return selector.replace(/^html[^\b]*\bbody\b/, '').trim();
     }
 
+    function getValidVariableName(name) {
+        if (name.length && !/[$_a-zA-Z]/.test(name[0])) {
+            return '_' + name;
+        }
+        return name;
+    }
+
     function getDefinition(input) {
         input = input || {};
         var actionLowered = input.action.toLowerCase();
@@ -138,7 +145,7 @@ window.POG=(function() {
                 input.letters.attribute);
         }
 
-        buffer.attribute.name = getLetter(input.text, input.letters.attribute);
+        buffer.attribute.name = getValidVariableName(getLetter(input.text, input.letters.attribute));
         buffer.operation.documentation = input.action + suffixes.action +
             suffixes.documentation;
         buffer.operation.name = getLetter(input.action + suffixes.name,

--- a/src/common/generator.js
+++ b/src/common/generator.js
@@ -19,6 +19,7 @@ window.POG=(function() {
                 selector += '.' + value.trim().split(/\s+/g).join('.');
             }
             else {
+                value = value.replace(/\r?\n|\r/g, '');
                 selector += '[' + name + '=\'' + value + '\']';
             }
             if (document.querySelectorAll(selector).length === 1) {


### PR DESCRIPTION
In some cases, like when dealing with version names, rendered template may produce invalid java or c# variable names.

```java
    @FindBy(css = "a[href='/rickypc/selenium-page-object-generator/tree/1.0.1']")
    @CacheLookup
    private WebElement 101;

    @FindBy(css = "a[href='/rickypc/selenium-page-object-generator/tree/1.0.2']")
    @CacheLookup
    private WebElement 102;
```
This PR is to fix this. I have prefixed the variable names with an underscore:

```java
    @FindBy(css = "a[href='/rickypc/selenium-page-object-generator/tree/1.0.1']")
    @CacheLookup
    private WebElement _101;

    @FindBy(css = "a[href='/rickypc/selenium-page-object-generator/tree/1.0.2']")
    @CacheLookup
    private WebElement _102;
```