### PR TITLE
Adding support for Ruby and more functions

### DIFF
--- a/.idea/dictionaries/shir_cohen.xml
+++ b/.idea/dictionaries/shir_cohen.xml
@@ -1,0 +1,3 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="shir.cohen" />
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/selenium-page-object-generator.iml" filepath="$PROJECT_DIR$/.idea/selenium-page-object-generator.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/selenium-page-object-generator.iml
+++ b/.idea/selenium-page-object-generator.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="ModuleRunConfigurationManager">
+    <shared />
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Selenium Page Object Generator is also available in command line by installing [
 
 The template is using [Handlebars.js](http://handlebarsjs.com/) expression, a clean logic-less semantic templating language.
 
-This is an early BETA release, it expected to have rough edges, and limited functionality. It currently support 3 different targets: [Java](https://en.wikipedia.org/wiki/Java_(programming_language)), [C#](https://en.wikipedia.org/wiki/C_Sharp_(programming_language)), and [Robot Framework](http://robotframework.org/).
+This is an early BETA release, it expected to have rough edges, and limited functionality. It currently support 3 different targets: [Java](https://en.wikipedia.org/wiki/Java_(programming_language)), [C#](https://en.wikipedia.org/wiki/C_Sharp_(programming_language)), [Ruby](https://en.wikipedia.org/wiki/Ruby_(programming_language)) and [Robot Framework](http://robotframework.org/).
 
 For more information on how to use the generated Page Object file:
 
@@ -22,6 +22,8 @@ Java: [https://code.google.com/p/selenium/wiki/PageFactory#The](https://code.goo
 C#: [http://relevantcodes.com/pageobjects-and-pagefactory-design-patterns-in-selenium/#post-5229](http://relevantcodes.com/pageobjects-and-pagefactory-design-patterns-in-selenium/#post-5229)
 
 Robot Framework: [http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#taking-resource-files-into-use](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#taking-resource-files-into-use)
+
+Ruby: [https://github.com/cheezy/page-object](https://github.com/cheezy/page-object)
 
 (You need to use Chrome 40+ or Opera 15+ or Node.JS 5.x to try this out)
 
@@ -45,7 +47,7 @@ selenium-page-object-generator [options]
 
   -h, --help                                 Show this help message and exit.
   -v, --version                              Show program's version number and exit.
-  -t, --target {cs,java,robot}               Generator target
+  -t, --target {cs,java,robot, rb}           Generator target
   -n, --name [PageName]                      Page name (no-spaces)
   -d, --destination [DestinationPageName]    Destination page name (no-spaces) (optional)
   -s, --source [source.html]                 Source file

--- a/bin/generate.js
+++ b/bin/generate.js
@@ -11,7 +11,7 @@ var parser = new ArgumentParser({
 });
 
 parser.addArgument(['-t', '--target'], {
-    choices: ['cs', 'java', 'robot'],
+    choices: ['cs', 'java', 'robot', 'rb'],
     help: 'Generator target',
     required: true
 });
@@ -55,7 +55,8 @@ var paths = {
 var targets = {
     cs: { label: 'C#' },
     java: { label: 'Java' },
-    robot: { label: 'Robot Framework' }
+    robot: { label: 'Robot Framework' },
+    rb: { label: 'Ruby' }
 };
 
 function getFileContent(path) {

--- a/configs/rb.json
+++ b/configs/rb.json
@@ -1,0 +1,11 @@
+{
+  "attributes": {
+    "letter": 2,
+    "indent": 1,
+    "separator": "",
+    "customAttribute": ""
+  },
+  "operations": {
+    "letter": 2
+  }
+}

--- a/specs/common/common-spec.js
+++ b/specs/common/common-spec.js
@@ -386,7 +386,8 @@ describe('common.getStorage', function() {
                 targets: {
                     cs: { label: 'C#', config: values, template: '{{template}}' },
                     java: { label: 'Java', config: values, template: '{{template}}' },
-                    robot: { label: 'Robot Framework', config: values, template: '{{template}}' }
+                    robot: { label: 'Robot Framework', config: values, template: '{{template}}' },
+                    rb: { label: 'Ruby', config: values, template: '{{template}}' }
                 }
             });
         });
@@ -406,7 +407,8 @@ describe('common.getStorage', function() {
             handler({ targets: {
                 cs: { config: { timeout: 90 }, label: 'C#' },
                 java: { config: { timeout: 90 }, label: 'Java' },
-                robot: { config: { timeout: 90 }, label: 'Robot Framework' }
+                robot: { config: { timeout: 90 }, label: 'Robot Framework' },
+                rb: { config: { timeout: 90 }, label: 'Ruby' }
             } });
         });
         var response = common.common.getStorage();
@@ -428,7 +430,8 @@ describe('common.getStorage', function() {
                 targets: {
                     cs: { label: 'C#', config: values, template: '{{template}}' },
                     java: { label: 'Java', config: values, template: '{{template}}' },
-                    robot: { label: 'Robot Framework', config: values, template: '{{template}}' }
+                    robot: { label: 'Robot Framework', config: values, template: '{{template}}' },
+                    rb: { label: 'Ruby', config: values, template: '{{template}}' }
                 }
             });
         });
@@ -448,7 +451,8 @@ describe('common.getStorage', function() {
             handler({ targets: {
                 cs: { label: 'C#', template: '{{cached}}' },
                 java: { label: 'Java', template: '{{cached}}' },
-                robot: { label: 'Robot Framework', template: '{{cached}}' }
+                robot: { label: 'Robot Framework', template: '{{cached}}' },
+                rb: { label: 'Robot Framework', template: '{{cached}}' }
             } });
         });
         var response = common.common.getStorage();
@@ -470,7 +474,8 @@ describe('common.getStorage', function() {
                 targets: {
                     cs: { label: 'C#', config: values, template: '{{cached}}' },
                     java: { label: 'Java', config: values, template: '{{cached}}' },
-                    robot: { label: 'Robot Framework', config: values, template: '{{cached}}' }
+                    robot: { label: 'Robot Framework', config: values, template: '{{cached}}' },
+                    rb: { label: 'Ruby', config: values, template: '{{cached}}' }
                 }
             });
         });
@@ -507,7 +512,8 @@ describe('common.getStorage', function() {
                 targets: {
                     cs: { label: 'C#' },
                     java: { label: 'Java' },
-                    robot: { label: 'Robot Framework' }
+                    robot: { label: 'Robot Framework' },
+                    rb: { label: 'Ruby' }
                 }
             });
         });
@@ -548,7 +554,8 @@ describe('common.getStorage', function() {
                 targets: {
                     cs: { label: 'C#', template: '{{template}}' },
                     java: { label: 'Java', template: '{{template}}' },
-                    robot: { label: 'Robot Framework', template: '{{template}}' }
+                    robot: { label: 'Robot Framework', template: '{{template}}' },
+                    rb: { label: 'Ruby', template: '{{template}}' }
                 }
             });
         });
@@ -590,7 +597,8 @@ describe('common.getStorage', function() {
                 targets: {
                     cs: { config: values, label: 'C#' },
                     java: { config: values, label: 'Java' },
-                    robot: { config: values, label: 'Robot Framework' }
+                    robot: { config: values, label: 'Robot Framework' },
+                    rb: { config: values, label: 'Ruby' }
                 }
             });
         });
@@ -667,6 +675,16 @@ describe('common.setDefaultValues', function() {
             attributes.indent).toBeTruthy();
     });
 
+    it('should set attributes name format to false', function() {
+        expect(common.common.setDefaultValues().attributes.nameFormat).toBeFalsy();
+    });
+
+
+    it('should set attributes name format to input value', function() {
+        expect(common.common.setDefaultValues({ attributes: { nameFormat: true } }).
+            attributes.nameFormat).toBeTruthy();
+    });
+
     it('should set attributes separator to breakline', function() {
         expect(common.common.setDefaultValues().attributes.separator).toEqual('\n');
     });
@@ -674,6 +692,15 @@ describe('common.setDefaultValues', function() {
     it('should set attributes separator to input value', function() {
         expect(common.common.setDefaultValues({ attributes: { separator: 'a' } }).
             attributes.separator).toEqual('a');
+    });
+
+    it('should set attributes custom attribute to breakline', function() {
+        expect(common.common.setDefaultValues().attributes.customAttribute).toEqual('\n');
+    });
+
+    it('should set attributes custom attribute input value', function() {
+        expect(common.common.setDefaultValues({ attributes: { customAttribute: 'data-automations' } }).
+            attributes.customAttribute).toEqual('data-automations');
     });
 
     it('should set copyright hash', function() {
@@ -846,6 +873,15 @@ describe('common.setDefaultValues', function() {
 
     it('should set operations extras verify.url to input value', function() {
         expect(common.common.setDefaultValues({ operations: { extras: { 'verify.url': 0 } } }).
+            operations.extras['verify.url']).toEqual(0);
+    });
+
+    it('should set operation extras goto.page to default value', function() {
+        expect(common.common.setDefaultValues().operations.extras['goto.page']).toEqual(1);
+    });
+
+    it('should set operations extras goto.page to input value', function() {
+        expect(common.common.setDefaultValues({ operations: { extras: { 'goto.page': 0 } } }).
             operations.extras['verify.url']).toEqual(0);
     });
 

--- a/src/chrome/assets/css/options.css
+++ b/src/chrome/assets/css/options.css
@@ -103,6 +103,7 @@ fieldset label[for='model.include'],
 fieldset label[for='nodes.angular'],
 fieldset label[for^='operations.fill'],
 fieldset label[for='operations.submit'],
+fieldset label[for='operations.goto.page'],
 fieldset label[for^='operations.verify'] {
     width: 300px;
 }

--- a/src/chrome/assets/js/options.js
+++ b/src/chrome/assets/js/options.js
@@ -3,7 +3,9 @@ function getElements() {
         attributes: {
             indent: $('[id="attributes.indent"]'),
             letter: $('[id="attributes.letter"]'),
-            separator: $('[id="attributes.separator"]')
+            separator: $('[id="attributes.separator"]'),
+            nameFormat: $('[id="attributes.nameFormat"]'),
+            customAttribute: $('[id="attributes.customAttribute"]')
         },
         copyright: {
             claimant: $('[id="copyright.claimant"]'),
@@ -29,7 +31,8 @@ function getElements() {
                 'fill.submit': $('[id="operations.fill.submit"]'),
                 submit: $('[id="operations.submit"]'),
                 'verify.loaded': $('[id="operations.verify.loaded"]'),
-                'verify.url': $('[id="operations.verify.url"]')
+                'verify.url': $('[id="operations.verify.url"]'),
+                'goto.page': $('[id="operations.goto.page"]')
             },
             letter: $('[id="operations.letter"]'),
             separator: $('[id="operations.separator"]')
@@ -72,7 +75,9 @@ function pull(elements, target) {
     }
 
     target.config.attributes.indent = elements.attributes.indent.get(0).checked;
+    target.config.attributes.nameFormat = elements.attributes.nameFormat.get(0).checked;
     target.config.attributes.letter = elements.attributes.letter.val();
+    target.config.attributes.customAttribute = elements.attributes.customAttribute.val();
     target.config.attributes.separator = elements.attributes.separator.val().
         replace(/\\n/g, '\n');
 
@@ -90,6 +95,9 @@ function pull(elements, target) {
     target.config.nodes.selector = elements.nodes.selector.val();
     target.config.nodes.visibility = elements.nodes.visibility.val();
 
+    /*
+    set the default value of the options in the popup options to be checked
+     */
     target.config.operations.extras.fill = elements.operations.extras.fill.
         get(0).checked;
     target.config.operations.extras['fill.submit'] = elements.operations.
@@ -100,6 +108,8 @@ function pull(elements, target) {
         extras['verify.loaded'].get(0).checked;
     target.config.operations.extras['verify.url'] = elements.operations.
         extras['verify.url'].get(0).checked;
+    target.config.operations.extras['goto.page'] = elements.operations.
+        extras['goto.page'].get(0).checked;
 
     target.config.operations.letter = elements.operations.letter.val();
     target.config.operations.separator = elements.operations.separator.val().
@@ -116,9 +126,13 @@ function push(elements, target) {
 
     elements.attributes.indent.get(0).checked = !!target.config.
         attributes.indent;
+    elements.attributes.nameFormat.get(0).checked = !!target.config.
+        attributes.nameFormat;
     elements.attributes.letter.val(target.config.attributes.letter);
     elements.attributes.separator.val(target.config.attributes.
         separator.replace(/\n/g, '\\n'));
+
+    elements.attributes.customAttribute.val(target.config.attributes.customAttribute);
 
     elements.copyright.claimant.val(target.config.copyright.claimant);
     elements.copyright.year.val(target.config.copyright.year);
@@ -146,6 +160,8 @@ function push(elements, target) {
         operations.extras['verify.loaded'];
     elements.operations.extras['verify.url'].get(0).checked = !!target.config.
         operations.extras['verify.url'];
+    elements.operations.extras['goto.page'].get(0).checked = !!target.config.
+        operations.extras['goto.page'];
 
     elements.operations.letter.val(target.config.operations.letter);
     elements.operations.separator.val(target.config.operations.

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,5 +1,5 @@
 {
-    "author": "",
+    "author": "Shir Cohen",
 
     "browser_action": {
         "default_icon": {
@@ -8,10 +8,9 @@
         },
         "default_popup": "popup.html"
     },
-
     "content_security_policy": "script-src 'self' 'unsafe-eval' https://www.google-analytics.com; object-src 'self'",
 
-    "description": "",
+    "description": "Page Object generator for Ruby",
 
     "homepage_url": "https://github.com/rickypc/selenium-page-object-generator",
 
@@ -25,7 +24,7 @@
 
     "minimum_chrome_version": "40",
 
-    "name": "",
+    "name": "Ruby generator",
 
     "options_ui": {
         "chrome_style": true,
@@ -40,5 +39,5 @@
 
     "short_name": "PO Generator",
 
-    "version": ""
+    "version": "1.0"
 }

--- a/src/chrome/options.html
+++ b/src/chrome/options.html
@@ -27,11 +27,19 @@
                         <label for="attributes.indent">Indent:</label>
                         <input type="checkbox" id="attributes.indent">
                     </li>
+                    <li>
+                        <label for="attributes.nameFormat">Name format:</label>
+                        <input type="checkbox" id="attributes.nameFormat">
+                    </li>
                 </ul>
             </div>
             <div class="right valign">
                 <label for="attributes.separator">Separator:</label>
                 <input type="text" id="attributes.separator" value="">
+            </div>
+            <div class="right valign">
+                <label for="attributes.customAttribute">Custom attribute:</label>
+                <input type="text" id="attributes.customAttribute" value="">
             </div>
         </fieldset>
         <fieldset>
@@ -118,6 +126,10 @@
                 <li>
                     <label for="operations.verify.url">Include Verify Page URL:</label>
                     <input type="checkbox" id="operations.verify.url">
+                </li>
+                <li>
+                    <label for="operations.goto.page">Include go to page method:</label>
+                    <input type="checkbox" id="operations.goto.page">
                 </li>
                 <li>
                     <div class="left">

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -90,6 +90,15 @@
                 }
             }).promise();
         },
+
+        /**
+         * Get value for a given key
+         *
+         * @param {String} configKey
+         *   The key we are checking
+         * @param {Object} defaultValue
+         *   The value to put if configKey wasn't custom specify by the user
+         */
         getDefaultValue: function(configKey, defaultValue) {
             var env = (typeof(process) !== 'undefined' && process.env) ? process.env : null;
             var prefix = 'npm_package_config_';
@@ -114,7 +123,8 @@
                     storage.targets = storage.targets || {
                         cs: { label: 'C#' },
                         java: { label: 'Java' },
-                        robot: { label: 'Robot Framework' }
+                        robot: { label: 'Robot Framework' },
+                        rb: { label: 'Ruby' }
                     };
 
                     // first timer
@@ -191,8 +201,14 @@
             if (!input.attributes.indent) {
                 input.attributes.indent = !!this.getDefaultValue('attributes_indent', false);
             }
+            input.attributes.nameFormat = !!input.attributes.nameFormat;
+            if (!input.attributes.nameFormat) {
+                input.attributes.nameFormat = !!this.getDefaultValue('attributes_nameFormat', false);
+            }
             input.attributes.separator = this.defaults(input.attributes.separator,
                 this.getDefaultValue('attributes_separator', '\n'));
+            input.attributes.customAttribute = this.defaults(input.attributes.customAttribute,
+                this.getDefaultValue('attributes_customAttribute', '\n'));
 
             // copyright
             input.copyright = input.copyright || {};
@@ -249,6 +265,9 @@
             input.operations.extras['verify.url'] =
                 this.defaults(input.operations.extras['verify.url'],
                 this.getDefaultValue('extras_verify_url', 1));
+            input.operations.extras['goto.page'] =
+                this.defaults(input.operations.extras['goto.page'],
+                this.getDefaultValue('extras_goto_page', 1));
 
             input.operations.letter = input.operations.letter ||
                 this.getDefaultValue('operations_letter', root.LETTERS.CAMEL);

--- a/src/common/generator.js
+++ b/src/common/generator.js
@@ -148,7 +148,7 @@ window.POG = (function () {
         // Based on action type use the following suffixes to the documentation and method name
         var suffixes = {
             action: (actionLowered === 'click') ? ' on' : '',
-            label: (actionLowered === 'set') ? ' Field' : ''
+            label: (actionLowered === 'set') ? ' Field' : (actionLowered === 'see') ? ' visible?' : ''
         };
         suffixes.documentation = ' ' + getLetter(input.fullText || input.text, LETTERS.NATURAL) +
             ' ' + (input.label + suffixes.label.toLowerCase()) + '.';
@@ -172,9 +172,12 @@ window.POG = (function () {
         buffer.attribute.name = getValidVariableName(getLetter(input.text, input.letters.attribute));
         buffer.operation.documentation = input.action + suffixes.action +
             suffixes.documentation;
-        buffer.operation.name = getLetter(input.action + suffixes.name,
-            input.letters.operation, input.action);
-
+        //If the action is "see" we want to create a method with suffix "_visible?" so we don't put the action in the method name
+        buffer.operation.name = (actionLowered === 'see')
+            ? getLetter(suffixes.name,
+                input.letters.operation, suffixes.name)
+            : getLetter(input.action + suffixes.name,
+                input.letters.operation, input.action);
         return buffer;
     }
 
@@ -665,7 +668,7 @@ window.POG = (function () {
                     case 'A':
                         action = 'Click';
                         buffer.type = 'link';
-                        label = 'Link';
+                        label = '';
                         text = ((input.attributes.nameFormat === true) ? text || getLinkText(node) : locator.value).toLowerCase();
 
                         if (submit.text === '' && text.toLowerCase().indexOf('submit') > -1) {
@@ -676,7 +679,7 @@ window.POG = (function () {
                     case 'BUTTON':
                         action = 'Click';
                         buffer.type = 'button';
-                        label = 'Button';
+                        label = '';
 
                         if (submit.text === '' && ((node.type || '').toLowerCase() === 'submit' ||
                                 text.toLowerCase().indexOf('submit') > -1)) {
@@ -961,7 +964,7 @@ window.POG = (function () {
                 },
                 operation: {
                     documentation: 'Verify that the page loaded completely.',
-                    name: getLetter('Verify Page Loaded', input.operations.letter)
+                    name: getLetter('loaded?', input.operations.letter)
                 },
                 sourceIndex: -1,
                 type: 'verify.loaded'

--- a/src/common/generator.js
+++ b/src/common/generator.js
@@ -1,9 +1,9 @@
 window.POGLoaded = !!window.POG;
-window.POG=(function() {
+window.POG = (function () {
     // to compartment any js error on the page
     var ELEMENT_NODE = 1;
-    var NG_PREFIXES = ['ng-','data-ng-','ng_','x-ng-','ng\\:'];
-    var NG_STRATEGIES = [ { handler: getNgModelName, strategy: 'model' } ];
+    var NG_PREFIXES = ['ng-', 'data-ng-', 'ng_', 'x-ng-', 'ng\\:'];
+    var NG_STRATEGIES = [{handler: getNgModelName, strategy: 'model'}];
     var SHOW_COMMENT = 128;
 
     // ========================================================================
@@ -120,6 +120,23 @@ window.POG=(function() {
         return name;
     }
 
+    /**
+     * Build a definition
+     *
+     * For a given element, we create attribute and relevant methods based on the element type
+     *
+     * @param {Associative Array} input
+     *
+     * Element properties
+     *
+     * @return {Associative Array} buffer
+     *   Object that contains the attribute name (Object.attribute.name), the method name (Object.operation.name)
+     *   documentation for each method (buffer.operation.documentation) based on the element type
+     *
+     * In order to build the method documentation we use "action" key
+     * In order to build the method name we use "label" key
+     *
+     */
     function getDefinition(input) {
         input = input || {};
         var actionLowered = input.action.toLowerCase();
@@ -127,6 +144,8 @@ window.POG=(function() {
         // deep copy
         buffer.attribute = Object.extend(buffer.attribute);
         buffer.operation = Object.extend(buffer.operation);
+
+        // Based on action type use the following suffixes to the documentation and method name
         var suffixes = {
             action: (actionLowered === 'click') ? ' on' : '',
             label: (actionLowered === 'set') ? ' Field' : ''
@@ -168,7 +187,7 @@ window.POG=(function() {
         var originals = original.getElementsByTagName('*');
         var hiddens = (cloned) ? Array.filter(cloned.querySelectorAll(
             '*:not(br):not(img):not(input):not(link):not(option):not(script):not(select):not(style)'
-        ), function(item, index) {
+        ), function (item, index) {
             var sourceIndex = [].indexOf.call(clones, item);
             return originals[sourceIndex].offsetHeight < 1 || !isElementInViewport(item);
         }) : [];
@@ -217,7 +236,7 @@ window.POG=(function() {
 
             if (text === '') {
                 var identifierLowered = identifier.toLowerCase();
-                var labels = Array.filter(document.querySelectorAll('label[for]'), function(item) {
+                var labels = Array.filter(document.querySelectorAll('label[for]'), function (item) {
                     return item.getAttribute('for').toLowerCase() === identifierLowered;
                 });
 
@@ -256,18 +275,17 @@ window.POG=(function() {
                 break;
             case LETTERS.CAMEL:
             case LETTERS.PROPER:
-                value = value.replace(/\./g, ' ').trim().replace(/\s\s+/g, ' ').
-                    replace(/\w\S*/g, function(word) {
-                        return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
-                    }).replace(/\s+/g, '');
+                value = value.replace(/\./g, ' ').trim().replace(/\s\s+/g, ' ').replace(/\w\S*/g, function (word) {
+                    return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
+                }).replace(/\s+/g, '');
                 if (type === LETTERS.CAMEL) {
                     value = value.charAt(0).toLowerCase() + value.substr(1);
                 }
                 break;
             case LETTERS.NATURAL:
-                value = value.trim().replace(/\s\s+/g, ' ').replace(/\w\S*/g, function(word) {
-                        return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
-                    });
+                value = value.trim().replace(/\s\s+/g, ' ').replace(/\w\S*/g, function (word) {
+                    return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
+                });
                 break;
         }
 
@@ -285,7 +303,21 @@ window.POG=(function() {
         return text.trim();
     }
 
-    function getLocator(node, angular) {
+    /**
+     * Get the Element locator
+     *
+     * For a given element, we extract the element locator based on angular attribute, custom attribute or regular
+     * HTML attributes (id, name, css etc.)
+     *
+     * @param {HTML Element} node
+     * @param {Boolean} angular
+     * @param {String} customAttribute
+     *
+     * @return {Associative Array} response
+     *   Object that contains the attribute type (Object.strategy) and the attribute value (response.value)
+     *
+     */
+    function getLocator(node, angular, customAttribute) {
         var response = {};
 
         if (angular) {
@@ -293,7 +325,11 @@ window.POG=(function() {
         }
 
         if (!response.strategy) {
-            if (node.id) {
+            if (customAttribute && node.getAttribute(customAttribute)) {
+                response.strategy = customAttribute.replace("-","_");
+                response.value = node.getAttribute(customAttribute);
+            }
+            else if (node.id) {
                 response.strategy = 'id';
                 response.value = node.id;
             }
@@ -370,7 +406,7 @@ window.POG=(function() {
         nodeName = nodeName || node.nodeName;
 
         var siblings = (node && node.parentNode) ?
-            Array.filter(node.parentNode.children, function(item, index) {
+            Array.filter(node.parentNode.children, function (item, index) {
                 return item.nodeName === nodeName;
             }) : [];
 
@@ -466,7 +502,7 @@ window.POG=(function() {
         }
 
         // desc
-        sentences.sort(function(a, b) {
+        sentences.sort(function (a, b) {
             return sentences.frequencies[b] - sentences.frequencies[a];
         });
 
@@ -480,12 +516,11 @@ window.POG=(function() {
         words.frequencies = {};
         words.tops = [];
 
-        text.toLowerCase().split(/[\s*\.*\,\;\+?\#\|:\-\/\\\[\]\(\)\{\}$%&0-9*]/).
-            map(function(k, v) {
-                if (k && k.length > 1) {
-                    words.frequencies[k]++ || (words.frequencies[k] = 1);
-                }
-            });
+        text.toLowerCase().split(/[\s*\.*\,\;\+?\#\|:\-\/\\\[\]\(\)\{\}$%&0-9*]/).map(function (k, v) {
+            if (k && k.length > 1) {
+                words.frequencies[k]++ || (words.frequencies[k] = 1);
+            }
+        });
 
         for (var word in words.frequencies) {
             words[++index] = word;
@@ -496,8 +531,12 @@ window.POG=(function() {
         }
 
         // desc
-        words.sort(function(a, b) { return words.frequencies[b] - words.frequencies[a]; });
-        words.tops.sort(function(a, b) { return words.frequencies[b] - words.frequencies[a]; });
+        words.sort(function (a, b) {
+            return words.frequencies[b] - words.frequencies[a];
+        });
+        words.tops.sort(function (a, b) {
+            return words.frequencies[b] - words.frequencies[a];
+        });
 
         return words;
     }
@@ -520,17 +559,20 @@ window.POG=(function() {
         var type = {}.toString.call(nodes);
 
         if (type !== '[object Array]' &&
-                !(type === '[object NodeList]' || type === '[object Object]')) {
+            !(type === '[object NodeList]' || type === '[object Object]')) {
             return;
         }
 
         var index = -1;
         var length = nodes.length;
 
-        while(++index < length) {
+        while (++index < length) {
             var node = nodes[index];
             if (node) {
-                (node.parentNode || { removeChild: function() {} }).removeChild(node);
+                (node.parentNode || {
+                    removeChild: function () {
+                    }
+                }).removeChild(node);
             }
         }
     }
@@ -552,9 +594,24 @@ window.POG=(function() {
         return clonedNode;
     }
 
+    /**
+     * Create the Page Object content
+     *
+     * Based on a given options, it extract all the relevant data from the page and creates
+     * the page object file content
+     *
+     * @param {Associative Array} input
+     *
+     * Object that contains chosen options by the user
+     *
+     * @return {Associative Array} input
+     *   Object that contains the Page Object content
+     *
+     */
     function setDefinitions(input) {
         var definitions = [];
         var root = document.querySelector(input.nodes.root) || document;
+        // nodes contains all the elements we find on the page that fit our options selection
         var nodes = (root) ? root.querySelectorAll(input.nodes.selector) : [];
         var type = {}.toString.call(nodes);
 
@@ -567,14 +624,15 @@ window.POG=(function() {
         var hasField = false;
         var index = -1;
         var longestName = 0;
-        var submit = { label: '', text: '' };
+        var submit = {label: '', text: ''};
         var tags = document.getElementsByTagName('*');
         var texts = {};
         var unsets = {};
         var visibleOnly = (parseInt(input.nodes.visibility) === VISIBILITIES.VISIBLE);
 
+        // for each element we found on the page do the following
         for (var i = 0, j = nodes.length; i < j; i++) {
-            var buffer = { attribute: {}, operation: {} };
+            var buffer = {attribute: {}, operation: {}};
             var definition = {};
             var node = nodes[i];
 
@@ -583,19 +641,32 @@ window.POG=(function() {
                 var hasArgument = false;
                 var hasUnset = false;
                 var label = '';
-                var locator = getLocator(node, input.nodes.angular);
+                // If the user entered a custom attribute, try to look for this attribute on the element
+                var locator = (input.attributes.customAttribute !== '')
+                    ? getLocator(node, input.nodes.angular, input.attributes.customAttribute)
+                    : getLocator(node, input.nodes.angular);
                 var text = node.textContent || node.innerText || '';
 
+                //locator.strategy is the attribute of the element
                 buffer.attribute.strategy = locator.strategy;
+                //locator.value is the value of this attribute
                 buffer.attribute.value = locator.value;
                 buffer.sourceIndex = node.sourceIndex || [].indexOf.call(tags, node);
 
-                switch(node.nodeName) {
+                /*
+                Switch case which determine the element page object format:
+                - node.nodeName is the element type (A, BUTTON, DIV etc.)
+                - action will determine which method we will create for each Page Object
+                - label will add a word to the end of the method name
+                - text will effect the Page Object name (if nameFormat is true we will use the element inner text
+                  to set the name, if not, we will use the attribute value.
+                 */
+                switch (node.nodeName) {
                     case 'A':
                         action = 'Click';
                         buffer.type = 'link';
                         label = 'Link';
-                        text = text || getLinkText(node);
+                        text = ((input.attributes.nameFormat === true) ? text || getLinkText(node) : locator.value).toLowerCase();
 
                         if (submit.text === '' && text.toLowerCase().indexOf('submit') > -1) {
                             submit.label = label;
@@ -620,17 +691,17 @@ window.POG=(function() {
                             action = 'Click';
                             buffer.type = 'button';
                             label = 'Button';
-                            text = text || node.value || getNodeText(node);
+                            text = ((input.attributes.nameFormat === true) ? text || node.value || getNodeText(node) : locator.value).toLowerCase();
+
 
                             if (inputType === 'submit') {
                                 submit.label = label;
                                 submit.text = text;
                             }
-                            else if (submit.text === '' && text.toLowerCase().
-                                indexOf('submit') > -1) {
-                                    submit.label = label;
-                                    submit.text = text;
-                                }
+                            else if (submit.text === '' && text.toLowerCase().indexOf('submit') > -1) {
+                                submit.label = label;
+                                submit.text = text;
+                            }
                         }
                         else {
                             if (inputType === 'hidden') {
@@ -639,13 +710,12 @@ window.POG=(function() {
                             else if (inputType === 'checkbox') {
                                 hasUnset = true;
                             }
-                            else if ('|email|number|password|radio|search|tel|text|url|'.
-                                    indexOf('|' + inputType + '|') > -1) {
+                            else if ('|email|number|password|radio|search|tel|text|url|'.indexOf('|' + inputType + '|') > -1) {
                                 hasArgument = true;
                             }
 
                             label = getLetter(inputType, LETTERS.PROPER);
-                            text = text || getNodeText(node);
+                            text = ((input.attributes.nameFormat === true) ? text || getNodeText(node) : locator.value).toLowerCase();
 
                             if (inputType === 'radio') {
                                 label = 'Radio Button';
@@ -672,8 +742,7 @@ window.POG=(function() {
                                     longestName);
                             }
 
-                            if ('|email|number|password|search|tel|url|'.
-                                    indexOf('|' + inputType + '|') > -1) {
+                            if ('|email|number|password|search|tel|url|'.indexOf('|' + inputType + '|') > -1) {
                                 inputType = 'text';
                             }
 
@@ -687,21 +756,37 @@ window.POG=(function() {
                         hasArgument = true;
                         hasUnset = true;
                         label = 'Drop Down List';
-                        text = getNodeText(node);
+                        text = ((input.attributes.nameFormat === true) ? getNodeText(node) : locator.value).toLowerCase();
                         break;
                     case 'TEXTAREA':
                         action = 'Set';
                         buffer.type = 'text';
                         hasArgument = true;
                         label = 'Textarea';
-                        text = getNodeText(node);
+                        text = ((input.attributes.nameFormat === true) ? getNodeText(node) : locator.value).toLowerCase();
+                        break;
+                    case 'DIV':
+                        action = 'See';
+                        buffer.type = 'div';
+                        label = '';
+                        text = ((input.attributes.nameFormat === true) ? getNodeText(node) : locator.value).toLowerCase();
+                        break;
+                    case 'SPAN':
+                        action = 'See';
+                        buffer.type = 'span';
+                        label = '';
+                        text = ((input.attributes.nameFormat === true) ? getNodeText(node) : locator.value).toLowerCase();
                         break;
                 }
 
-                var fullText = getSanitizedText(text);
-                text = getSanitizedText(text, 6);
+                var fullText = (input.attributes.nameFormat === true) ? getSanitizedText(text) : text;
+                text = (input.attributes.nameFormat === true) ? getSanitizedText(text, 6) : text;
 
                 if (text !== '') {
+                    /*
+                    if we already have an attribute with the same name, so we need to add a number to the
+                     name and change the index to make it unique.
+                     */
                     if (texts[text]) {
                         texts[text]++;
 
@@ -742,7 +827,7 @@ window.POG=(function() {
                                 definitions[unsets[text]] = definition;
                             }
                         }
-
+                        buffer.attribute.index = texts[text] - 1;
                         text = text + ' ' + texts[text];
                     }
                     else {
@@ -865,7 +950,7 @@ window.POG=(function() {
 
             // !robot
             if (input.attributes.letter !== LETTERS.LOWER && input.attributes.indent !== 1 &&
-                    input.attributes.separator !== '') {
+                input.attributes.separator !== '') {
                 sentence = sentence.replace(/"/g, '\\"');
             }
 
@@ -917,7 +1002,7 @@ window.POG=(function() {
     // POG namespace
 
     return {
-        generate: function(input) {
+        generate: function (input) {
             input = input || {};
             var output = Object.extend(input);
 
@@ -933,7 +1018,7 @@ window.POG=(function() {
 })();
 
 if (!window.POGLoaded) {
-    chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+    chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         if (!sender.tab && request.input) {
             sendResponse(POG.generate(request.input));
         }

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -1,3 +1,8 @@
+/* Block helpers for templates
+Block helpers make it possible to define custom iterators and other functionality that can invoke
+the passed block with a new context.
+*/
+
 Handlebars.registerHelper('attributes', function(options) {
     var root = options.data.root;
 

--- a/templates/rb.handlebars
+++ b/templates/rb.handlebars
@@ -1,0 +1,115 @@
+{{#if copyright.claimant}}
+/*
+All the code that follow is
+Copyright (c) {{copyright.year}}, {{copyright.claimant}}. All Rights Reserved.
+Not for reuse without permission.
+*/
+{{/if}}
+class {{model.name}}
+  include PageObject
+
+    {{#attributes}}
+    {{#if attribute.strategy}}
+    {{#equals type 'button'}}
+    {{#if attribute.index}}
+    button(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}', :index => {{attribute.index}})
+    {{else}}
+    button(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}')
+    {{/if}}
+    {{/equals}}
+    {{#equals type 'div'}}
+    {{#if attribute.index}}
+    div(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}', :index => {{attribute.index}})
+    {{else}}
+    div(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}')
+    {{/if}}
+    {{/equals}}
+    {{#equals type 'span'}}
+    {{#if attribute.index}}
+    span(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}', :index => {{attribute.index}})
+    {{else}}
+    span(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}')
+    {{/if}}
+    {{/equals}}
+    {{#equals type 'link'}}
+    {{#if attribute.index}}
+    link(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}', :index => {{attribute.index}})
+    {{else}}
+    link(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}')
+    {{/if}}
+    {{/equals}}
+    {{#equals type 'text'}}
+    {{#if attribute.index}}
+    input(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}', :index => {{attribute.index}})
+    {{else}}
+    input(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}')
+    {{/if}}
+    {{/equals}}
+    {{#equals type 'checkbox'}}
+    {{#if attribute.index}}
+    checkbox(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}', :index => {{attribute.index}})
+    {{else}}
+    checkbox(:{{{attribute.name}}}, :{{attribute.strategy}} => '{{{attribute.value}}}')
+    {{/if}}
+    {{/equals}}
+    {{else}}
+    {{attribute.name}} = "{{{attribute.value}}}"
+    {{/if}}
+    {{/attributes}}
+
+
+    {{#operations}}
+    # {{operation.documentation}}
+
+    def {{operation.name}}()
+    {{#equals type 'button'}}
+        self.{{attribute.name}}_element.when_present(10).click
+    {{/equals}}
+    {{#equals type 'text'}}
+        self.{{attribute.name}} = "placeholder"
+    {{/equals}}
+    {{#equals type 'checkbox'}}
+        self.{{attribute.name}}_element.when_present(10).click
+    {{/equals}}
+    {{#equals type 'link'}}
+        self.{{attribute.name}}_element.when_present(10).click
+    {{/equals}}
+    {{#equals type 'div'}}
+        self.{{attribute.name}}_element.when_present(10)
+    {{/equals}}
+    {{#equals type 'span'}}
+        self.{{attribute.name}}_element.when_present(10)
+    {{/equals}}
+    {{#equals type 'radio'}}
+        self.{{attribute.name}}_element.when_present(10).click
+    {{/equals}}
+    {{#equals type 'select'}}
+        self.{{attribute.name}}_element.when_present(10).click
+    {{/equals}}
+    {{#equals type 'verify.loaded'}}
+        self.{{attribute.name}}_element.check_exists
+    {{/equals}}
+    {{#equals type 'goto.page'}}
+        $mh_base_url + page_url
+    {{/equals}}
+    {{#equals type 'fill'}}
+    {{#fill}}
+        self.{{attribute.name}} = "placeholder"
+    {{/fill}}
+    {{/equals}}
+    {{#equals type 'fill.submit'}}
+        self.fill()
+        self.submit()
+    {{/equals}}
+    {{#equals type 'submit'}}
+        self.{{target.name}}();
+    {{/equals}}
+    {{#equals type 'verify.url'}}
+        assert(@browser.url.include?({{attribute.name}}), "The page URL is #{@browser.url} when it shouldn't")
+    {{/equals}}
+    end
+
+    {{/operations}}
+
+
+end


### PR DESCRIPTION
1. Adding support in generating Ruby page objects with all existing functionality (click methods, generate page objects, fill method, fill and submit method and verify URL method)
2. Adding support in custom attributes (e.g. "data-automations")
3. Adding support in scanning div/span
4. Adding support in verify visible methods (for elements of type div & span)
5. Adding "go to page" method (method with page URL)
6. Adding documentation to main functions
7. Adding "name format" option to let the user decide if he wants to use the element's inner text to determine the page object name or to use the attribute value.
8. Adding support to "index" param on Ruby templates when the attribute value is identical to another page object.